### PR TITLE
 IE-2664 change www -> app line 33

### DIFF
--- a/shared/iformbuilder/api.lua
+++ b/shared/iformbuilder/api.lua
@@ -30,7 +30,7 @@ local function fetchAccessToken(ClientKey, ClientSecret, CacheToken)
  
    local IssuedAt  = os.ts.gmtime()
    local ExpiresAt = IssuedAt + 60 * 9
-   local Url = "https://www.iformbuilder.com/exzact/api/oauth/token"
+   local Url = "https://api.iformbuilder.com/exzact/api/oauth/token"
    local Payload={iss=ClientKey, aud=Url,
                   exp=ExpiresAt, iat=IssuedAt }
    trace("iss="..ClientKey)


### PR DESCRIPTION
Change from ticket IE-2664 The iformbuilder api module in the sample channel from https://help.interfaceware.com/v6/oauth2-with-iformbuilder currently calls an outdated url to retrieve the OAuth token. The url can be found on line 33. It currently has 'https://www.iformbuilder.com/exzact/api/oauth/token' and should be updated to 'https://*app.*iformbuilder.com/exzact/api/oauth/token'.